### PR TITLE
fixes that the player score was not shown after finishing a run

### DIFF
--- a/gamemanager/gamemanager.gd
+++ b/gamemanager/gamemanager.gd
@@ -119,7 +119,7 @@ func _show_lose_screen() -> void:
 	var win_screen: Control = load("res://ui/screens/win-screen/win_screen.tscn").instantiate()
 	win_screen.tree_exited.connect(_show_title_screen)
 	add_child(win_screen)
-	win_screen.set_score(score) # we have to subtract 3 because lost levels also increment this "score"
+	win_screen.set_score(score)
 	for child in get_children():
 		if child is Level:
 			child.queue_free()


### PR DESCRIPTION
The final screen did not correctly show the player score in the score label, instead just having "Score: ".

THis PR fixes this by setting the score correctly